### PR TITLE
Fix battle buttons animating too far when spammed

### DIFF
--- a/core/src/com/majalis/battle/Battle.java
+++ b/core/src/com/majalis/battle/Battle.java
@@ -553,6 +553,7 @@ public class Battle extends Group{
 	}
 	
 	private void displayTechniqueOptions() {
+		techniquePane.clearActions();
 		techniqueTable.clear();
 		Array<Technique> options = character.getPossibleTechniques(enemy);
 		optionButtons = new Array<TextButton>();


### PR DESCRIPTION
Spamming buttons during a battle will cause them to animate too far to the left because of leftover `moveBy` actions. This fixes it by clearing the actions on the pane before refilling it.